### PR TITLE
Track each loop execution separately

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,30 @@ testBrokenLoop('for without body', (c) => {
   for (let i = 0; c(); i++) void(0);
 });
 
+testBrokenLoop('nested infinite for loops', (c) => {
+  for (let i = 0; c(); i++) {
+    for (let j = 0; c(); j++) {
+      void(0);
+    }
+  }
+});
+
+testBrokenLoop('inner infinite for loop', (c) => {
+  for (let i = 0; i < 10; i++) {
+    for (let j = 0; c(); j++) {
+      void(0);
+    }
+  }
+});
+
+testBrokenLoop('outer infinite for loop', (c) => {
+  for (let i = 0; c(); i++) {
+    for (let j = 0; j < 10; j++) {
+      void(0);
+    }
+  }
+});
+
 testBrokenLoop('do-while with body', (c) => {
   do {
     void(0);


### PR DESCRIPTION
Previously we counted the total number of loop executions and total time elapsed across all loops. This would yield false positives in plenty of obviously innocuous cases. Instead, assign each loop an index, and track the iteration count and start time separately for each index.